### PR TITLE
Make passgen command a little more useful.

### DIFF
--- a/cjdcmd.go
+++ b/cjdcmd.go
@@ -386,7 +386,7 @@ func main() {
 		}
 
 	case passGenCmd:
-		if len(data[0]) > 0 {
+		if len(data) > 0 && len(data[0]) > 0 {
 			fmt.Println(data[0] + "_" + randString(25, 50))
 		} else {
 			fmt.Println(randString(25, 50))

--- a/cjdcmd.go
+++ b/cjdcmd.go
@@ -386,8 +386,12 @@ func main() {
 		}
 
 	case passGenCmd:
-		// TODO(inies): Make more good
-		fmt.Println(randString(15, 50))
+		if len(data[0]) > 0 {
+			fmt.Println(data[0] + "_" + randString(25, 50))
+		} else {
+			fmt.Println(randString(25, 50))
+		}
+
 
 	case pubKeyToIPcmd:
 		var ip []byte

--- a/misc.go
+++ b/misc.go
@@ -338,7 +338,7 @@ func usage() {
 	fmt.Println("addpass [-file] [-outfile] [password]                adds the password to the config if one was supplied, or generates one and then adds")
 	fmt.Println("cleanconfig [-file] [-outfile]                       strips all comments from the config file and then saves it nicely formatted")
 	fmt.Println("log [-l level] [-logfile file] [-line line]          prints cjdns log to stdout")
-	fmt.Println("passgen                                              generates a random alphanumeric password between 15 and 50 characters in length")
+	fmt.Println("passgen [prefix]                                     generates a random alphanumeric password between 15 and 50 characters. If you provide [prefix], it will be prepended. This is to help you keep track of your peering passwords")
 	fmt.Println("peers                                                displays a list of currently connected peers")
 	fmt.Println("dump                                                 dumps the routing table to stdout")
 	fmt.Println("kill                                                 tells cjdns to gracefully exit")


### PR DESCRIPTION
Allow users to prepend stuff to the passwords by appending an argument
to passgen. Intended to make it easier for people to keep track of
peering passwords.
