### PR TITLE
Add command to change HypeDNS hostname

### DIFF
--- a/cjdcmd.go
+++ b/cjdcmd.go
@@ -60,6 +60,7 @@ const (
 	pubKeyToIPcmd = "ip"
 	passGenCmd    = "passgen"
 	hostCmd       = "host"
+	hostNameCmd   = "hostname"
 	cleanCfgCmd   = "cleanconfig"
 	addPeerCmd    = "addpeer"
 	addPassCmd    = "addpass"
@@ -338,6 +339,19 @@ func main() {
 
 	case addPeerCmd:
 		addPeer(data)
+
+	case hostNameCmd:
+		if len(data) == 1 {
+			setHypeDNS(data[0])
+			return
+		}
+		if len(data) > 1 {
+			fmt.Println("Too many arguments.")
+			return
+		}
+		fmt.Println("Didn't provide a new hostname")
+		fmt.Println("Haven't implemented the feature to get hostnames yet.")
+		return
 
 	case hostCmd:
 		if len(data) == 0 {

--- a/cjdcmd.go
+++ b/cjdcmd.go
@@ -341,6 +341,10 @@ func main() {
 		addPeer(data)
 
 	case hostNameCmd:
+		if len(data) == 0 {
+			setHypeDNS("")
+			return
+		}
 		if len(data) == 1 {
 			setHypeDNS(data[0])
 			return
@@ -349,8 +353,6 @@ func main() {
 			fmt.Println("Too many arguments.")
 			return
 		}
-		fmt.Println("Didn't provide a new hostname")
-		fmt.Println("Haven't implemented the feature to get hostnames yet.")
 		return
 
 	case hostCmd:

--- a/dns.go
+++ b/dns.go
@@ -16,7 +16,9 @@ package main
 import (
 	"fmt"
 	"github.com/miekg/dns"
+	"io/ioutil"
 	"net"
+	"net/http"
 	"strings"
 )
 
@@ -65,6 +67,24 @@ func reverseHypeDNSLookup(ip string) (response string, err error) {
 		return columns[4], nil
 	}
 	return
+}
+
+// Create a HypeDNS name for this device
+func setHypeDNS(hostname string) (response string, err error) {
+	setLoc := "/_hypehost/set?hostname="
+	nodeInfoHost :=  "http://[fc5d:baa5:61fc:6ffd:9554:67f0:e290:7535]:8000"
+
+	resp, err := http.Get(nodeInfoHost + setLoc + hostname)
+	if err != nil {
+		fmt.Println("Got an error, %s", err)
+		err = fmt.Errorf("Got an error when attempting to change hostname. Try again later")
+		return "", err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	fmt.Println()
+	return "Hostname " + string(body) + " created.", nil
 }
 
 // Resolve an IP to a domain name using the system DNS settings first, then HypeDNS

--- a/dns.go
+++ b/dns.go
@@ -72,19 +72,36 @@ func reverseHypeDNSLookup(ip string) (response string, err error) {
 // Create a HypeDNS name for this device
 func setHypeDNS(hostname string) (response string, err error) {
 	setLoc := "/_hypehost/set?hostname="
+	getLoc := "/_hypehost/get"
 	nodeInfoHost :=  "http://[fc5d:baa5:61fc:6ffd:9554:67f0:e290:7535]:8000"
 
+	if len(hostname) == 0 {
+		// The request is a "get"
+		resp, err := http.Get(nodeInfoHost + getLoc)
+		if err != nil {
+			fmt.Println("Got an error, %s", err)
+			err = fmt.Errorf("Got an error when attempting to retrieve " +
+			"hostname. This is usually because you can't connect to HypeDNS. " +
+			"Try again later")
+			return "", err
+		}
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		fmt.Println("You are: " + string(body))
+		return "", nil
+	}
+	// The request is a "set"
 	resp, err := http.Get(nodeInfoHost + setLoc + hostname)
 	if err != nil {
 		fmt.Println("Got an error, %s", err)
-		err = fmt.Errorf("Got an error when attempting to change hostname. Try again later")
+		err = fmt.Errorf("Got an error when attempting to change hostname. " +
+		"Try again later")
 		return "", err
 	}
-
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
-	fmt.Println()
-	return "Hostname " + string(body) + " created.", nil
+	fmt.Println("Hostname " + string(body) + " created.")
+	return "", nil
 }
 
 // Resolve an IP to a domain name using the system DNS settings first, then HypeDNS

--- a/misc.go
+++ b/misc.go
@@ -332,6 +332,7 @@ func usage() {
 	fmt.Println("traceroute <ipv6 address, hostname, or routing path> [-t timeout] performs a traceroute by pinging each known hop to the target on all known paths")
 	fmt.Println("ip <cjdns public key>                                converts a cjdns public key to the corresponding IPv6 address")
 	fmt.Println("host <ipv6 address or hostname>                      returns a list of all know IP address for the specified hostname or the hostname for an address")
+	fmt.Println("hostname [new HypeDNS hostname]                      without arguments, it will return your hostname on HypeDNS. Pass a hostname and it will make that your HypeDNS hostname.")
 	fmt.Println("cjdnsadmin <-file>                                   creates a .cjdnsadmin file in your home directory using the specified cjdroute.conf as input")
 	fmt.Println("addpeer [-file] [-outfile] '<json peer details>'     adds the peer details to your config file")
 	fmt.Println("addpass [-file] [-outfile] [password]                adds the password to the config if one was supplied, or generates one and then adds")

--- a/misc.go
+++ b/misc.go
@@ -332,7 +332,7 @@ func usage() {
 	fmt.Println("traceroute <ipv6 address, hostname, or routing path> [-t timeout] performs a traceroute by pinging each known hop to the target on all known paths")
 	fmt.Println("ip <cjdns public key>                                converts a cjdns public key to the corresponding IPv6 address")
 	fmt.Println("host <ipv6 address or hostname>                      returns a list of all know IP address for the specified hostname or the hostname for an address")
-	fmt.Println("hostname [new HypeDNS hostname]                      without arguments, it will return your hostname on HypeDNS. Pass a hostname and it will make that your HypeDNS hostname.")
+	fmt.Println("hostname [newname]                                   without arguments, it will return your hostname on HypeDNS. Pass a hostname and it will make that your HypeDNS hostname.")
 	fmt.Println("cjdnsadmin <-file>                                   creates a .cjdnsadmin file in your home directory using the specified cjdroute.conf as input")
 	fmt.Println("addpeer [-file] [-outfile] '<json peer details>'     adds the peer details to your config file")
 	fmt.Println("addpass [-file] [-outfile] [password]                adds the password to the config if one was supplied, or generates one and then adds")


### PR DESCRIPTION
Duplicate the functionality of the "hypehost" script within cjdcmd to help reduce the number of things that people need to install to take advantage of HypeDNS.
