### PR TITLE
Add simple Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+PROGRAM_NAME := cjdcmd
+GOCOMPILER := go build
+GOFLAGS	+= -ldflags "-X main.Version $(shell git describe --tags --dirty=+)"
+
+.PHONY: all clean
+
+all: $(DEPS) $(PROGRAM_NAME)
+
+$(PROGRAM_NAME): $(wildcard *.go)
+	$(GOCOMPILER) $(GOFLAGS)
+
+clean:
+	@- $(RM) $(PROGRAM_NAME)

--- a/cjdcmd.go
+++ b/cjdcmd.go
@@ -33,9 +33,9 @@ import (
 	"time"
 )
 
-const (
-	Version = "0.5.1"
+var Version = "0.5.1"
 
+const (
 	magicalLinkConstant = 5366870.0 //Determined by cjd way back in the dark ages.
 
 	defaultPingTimeout  = 5000 //5 seconds


### PR DESCRIPTION
This allows the build to be updated when required by `make`, rather than
a straight `go build`, which forces recompilation. This Makefile also
sets the `Version` variable to the output of `git describe --tags
--dirty=+`, so that the exact version of a binary can be determined.
