### PR TITLE
Fix typo

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -355,7 +355,7 @@ func usage() {
 	fmt.Println("")
 	fmt.Println("The commands are:")
 	fmt.Println("")
-	fmt.Println("ping <IPv6/DNS/Path>                         --  Preforms a cjdns ping to a specified node")
+	fmt.Println("ping <IPv6/DNS/Path>                         --  Performs a cjdns ping to a specified node")
 	fmt.Println("route <IPv6/DNS/Path>                        --  Prints all routes to a specific node")
 	fmt.Println("traceroute <IPv6/DNS/Path>                   --  Performs a traceroute on a specific node by pinging")
 	fmt.Println("                                                  each known hop to the tar on all known paths")


### PR DESCRIPTION
Changed "Preforms" to "Performs" which was bothering me every time I asked the utility for help.
